### PR TITLE
Add moony's merge tooling to the repo

### DIFF
--- a/Tools/mergetool.ps1
+++ b/Tools/mergetool.ps1
@@ -1,0 +1,38 @@
+Write-Output "Moony's upstream merge workflow tool."
+Write-Output "This tool can be stopped at any time, i.e. to finish a merge or resolve conflicts. Simply rerun the tool after having resolved the merge with normal git cli."
+Write-Output "Pay attention to any output from git!"
+$target = Read-Host "Enter the branch you're syncing toward (typically upstream/master or similar)"
+$refs = git log --reverse --format=format:%H HEAD.. $target
+
+$cherryPickOption = New-Object System.Management.Automation.Host.ChoiceDescription "&Cherry-pick","Uses git cherry pick to integrate the commit into the current branch. BE VERY CAREFUL WITH THIS."
+$mergeOption = New-Object System.Management.Automation.Host.ChoiceDescription "&Merge","Uses git merge to integrate the commit and any of it's children into the current branch."
+$skipOption = New-Object System.Management.Automation.Host.ChoiceDescription "&Skip","Skips introducing this commit."
+
+$mergeOptions = [System.Management.Automation.Host.ChoiceDescription[]]($skipOption, $mergeOption, $cherryPickOption)
+
+foreach ($unmerged in $refs) {
+    $summary = git show --format=format:%s $unmerged
+
+    if ($summary -ieq "automatic changelog update") {
+        Write-Output ("Deliberately skipping changelog bot commit {0}." -f $unmerged)
+        continue
+    }
+
+    git show --format=full --summary $unmerged
+
+    $response = $host.UI.PromptForChoice("Commit action?", "", $mergeOptions, 0)
+
+    Switch ($response) {
+        2 {
+            Write-Output "== GIT =="
+            git cherry-pick $unmerged
+            Write-Output "== DONE =="
+        }
+        1 {
+            Write-Output "== GIT =="
+            git merge $unmerged
+            Write-Output "== DONE =="
+        }
+        0 { Write-Output ("Skipping " -f $unmerged) }
+    }
+}


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
thanks to @moonheart08 for the tool.
should hopefully make upstream merges a bit less painful.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

no cl no fun