### PR TITLE
Beautify end screen and add support for start delay

### DIFF
--- a/Content.Server/_StationWare/Challenges/ChallengePrototype.cs
+++ b/Content.Server/_StationWare/Challenges/ChallengePrototype.cs
@@ -27,6 +27,13 @@ public sealed class ChallengePrototype : IPrototype
     public TimeSpan Duration = TimeSpan.FromSeconds(10);
 
     /// <summary>
+    /// A delay between the challenge announcement
+    /// and the actual challenge beginning.
+    /// </summary>
+    [DataField("startDelay")]
+    public TimeSpan StartDelay = TimeSpan.Zero;
+
+    /// <summary>
     /// The announcement played when the event starts
     /// </summary>
     [DataField("announcement")]

--- a/Content.Server/_StationWare/Challenges/StationWareChallengeComponent.cs
+++ b/Content.Server/_StationWare/Challenges/StationWareChallengeComponent.cs
@@ -6,14 +6,26 @@ namespace Content.Server._StationWare.Challenges;
 [RegisterComponent]
 public sealed class StationWareChallengeComponent : Component
 {
+    /// <summary>
+    /// The players and their entities who are involved in the challenge.
+    /// </summary>
     [DataField("participants")]
     public Dictionary<IPlayerSession, EntityUid> Participants = new();
 
+    /// <summary>
+    /// Whether or not the default case for the challenge is winning
+    /// </summary>
     [DataField("winByDefault")]
     public bool WinByDefault;
 
+    /// <summary>
+    /// Dictionary that stores whether or not each player has complete the challenge.
+    /// </summary>
     [DataField("completions"), ViewVariables(VVAccess.ReadWrite)]
     public Dictionary<IPlayerSession, bool?> Completions = new();
+
+    [DataField("startTime", customTypeSerializer: typeof(TimeOffsetSerializer))]
+    public TimeSpan? StartTime;
 
     [DataField("endTime", customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan EndTime;

--- a/Content.Server/_StationWare/Challenges/StationWareChallengeSystem.cs
+++ b/Content.Server/_StationWare/Challenges/StationWareChallengeSystem.cs
@@ -35,9 +35,9 @@ public sealed partial class StationWareChallengeSystem : EntitySystem
     public EntityUid StartChallenge(ChallengePrototype challengePrototype)
     {
         var uid = Spawn(null, MapCoordinates.Nullspace);
-
         var challengeComp = AddComp<StationWareChallengeComponent>(uid);
-        challengeComp.EndTime = _timing.CurTime + challengePrototype.Duration; // time modifiers?
+        challengeComp.StartTime = _timing.CurTime + challengePrototype.StartDelay;
+        challengeComp.EndTime = _timing.CurTime + challengePrototype.Duration + challengePrototype.StartDelay; // time modifiers?
         challengeComp.WinByDefault = challengePrototype.WinByDefault;
         challengeComp.Participants = GetParticipants(); // get all of the players for this challenge
 
@@ -59,10 +59,6 @@ public sealed partial class StationWareChallengeSystem : EntitySystem
 
         var announcement = Loc.GetString(challengePrototype.Announcement);
         _chat.DispatchGlobalAnnouncement(announcement, announcementSound: challengePrototype.AnnouncementSound, colorOverride: Color.Fuchsia);
-
-        // TODO: at some point, this should have a configurable delay
-        var ev = new ChallengeStartEvent(challengeComp.Participants.Values.ToList(), uid);
-        RaiseLocalEvent(uid, ref ev, true);
         return uid;
     }
 
@@ -83,6 +79,7 @@ public sealed partial class StationWareChallengeSystem : EntitySystem
         var ev = new ChallengeEndEvent(component.Participants.Values.ToList(), finalCompletions, uid);
         RaiseLocalEvent(uid, ref ev, true);
 
+        // TODO: we need to rejuv/respawn everyone we murdered
         Del(uid);
     }
 
@@ -138,11 +135,21 @@ public sealed partial class StationWareChallengeSystem : EntitySystem
 
         foreach (var challenge in EntityQuery<StationWareChallengeComponent>())
         {
-            var ent = challenge.Owner;
+            var uid = challenge.Owner;
+
+            if (challenge.StartTime != null &&
+                _timing.CurTime >= challenge.StartTime)
+            {
+                var ev = new ChallengeStartEvent(challenge.Participants.Values.ToList(), uid);
+                RaiseLocalEvent(uid, ref ev, true);
+                challenge.StartTime = null;
+            }
+
+
             if (_timing.CurTime < challenge.EndTime)
                 continue;
 
-            EndChallenge(ent, challenge);
+            EndChallenge(uid, challenge);
         }
     }
 }

--- a/Content.Server/_StationWare/GameRules/StationWareRuleSystem.cs
+++ b/Content.Server/_StationWare/GameRules/StationWareRuleSystem.cs
@@ -2,7 +2,9 @@
 using Content.Server._StationWare.Challenges;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules;
+using Content.Shared.CCVar;
 using Robust.Server.Player;
+using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
@@ -11,17 +13,18 @@ namespace Content.Server._StationWare.GameRules;
 
 public sealed class StationWareRuleSystem : GameRuleSystem
 {
+    [Dependency] private readonly IConfigurationManager _configuration = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly StationWareChallengeSystem _stationWareChallenge = default!;
 
     private TimeSpan _nextChallengeTime;
-    private readonly TimeSpan _challengeDelay = TimeSpan.FromSeconds(5); //CVAR
+    private TimeSpan _challengeDelay = TimeSpan.FromSeconds(5);
     private EntityUid? _currentChallenge;
 
-    private int _totalRounds = 2; //CVAR
-    private int _currentRound = 1;
+    private int _totalChallenges = 10;
+    private int _challengeCount = 1;
 
     private readonly Dictionary<IPlayerSession, int> _points = new();
 
@@ -33,7 +36,11 @@ public sealed class StationWareRuleSystem : GameRuleSystem
 
         SubscribeLocalEvent<ChallengeEndEvent>(OnChallengeEnd);
         SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEndText);
+
+        _configuration.OnValueChanged(CCVars.StationWareTotalChallenges, e => _totalChallenges = e, true);
+        _configuration.OnValueChanged(CCVars.StationWareChallengeCooldownLength, e => _challengeDelay = TimeSpan.FromSeconds(e), true);
     }
+
     private void OnChallengeEnd(ref ChallengeEndEvent ev)
     {
         if (ev.Challenge != _currentChallenge)
@@ -45,14 +52,16 @@ public sealed class StationWareRuleSystem : GameRuleSystem
                 AdjustPlayerScore(session);
         }
 
-        if (_currentRound == _totalRounds)
+        if (_challengeCount == _totalChallenges)
         {
             // TODO: make this slightly better
+            // more actionable plan: add a 10 second end-screen delay
+            // before booting everyone back into the lobby. (Deathmatch code)
             GameTicker.EndRound();
             GameTicker.RestartRound();
             return;
         }
-        _currentRound++;
+        _challengeCount++;
 
         _currentChallenge = null;
         _nextChallengeTime = _timing.CurTime + _challengeDelay;
@@ -63,15 +72,20 @@ public sealed class StationWareRuleSystem : GameRuleSystem
         if (_points.Count == 0)
             return;
 
-        foreach (var (session, points) in _points)
+        var orderedList = _points.OrderByDescending(x => x.Value).ToList();
+
+        for (var i = 0; i < orderedList.Count; i++)
         {
-            //TODO: loc, don't disappoint ruskis
-            ev.AddLine($"{session.Name} got {points} points.");
+            var (session, points) = orderedList[i];
+            ev.AddLine(Loc.GetString("stationware-report-score",
+                ("place", i + 1),
+                ("name", session.Name),
+                ("points", points)));
         }
 
-        var first = _points.First();
+        var first = orderedList.First();
         ev.AddLine("");
-        ev.AddLine($"{first.Key.Name} was the winner with a total of {first.Value} points.");
+        ev.AddLine(Loc.GetString("stationware-report-winner", ("name", first.Key.Name), ("points", first.Value)));
     }
 
     private void AdjustPlayerScore(IPlayerSession session)
@@ -83,7 +97,7 @@ public sealed class StationWareRuleSystem : GameRuleSystem
 
     public override void Started()
     {
-        _currentRound = 1;
+        _challengeCount = 1;
         _currentChallenge = null;
         _nextChallengeTime = _timing.CurTime + _challengeDelay;
     }
@@ -97,7 +111,6 @@ public sealed class StationWareRuleSystem : GameRuleSystem
         if (!RuleStarted)
             return;
 
-        // TODO: 5 second delay between challenges
         if (_currentChallenge != null)
             return;
 

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1168,6 +1168,18 @@ namespace Content.Shared.CCVar
          */
 
         /// <summary>
+        ///     How many challenges are in a single stationware round
+        /// </summary>
+        public static readonly CVarDef<int> StationWareTotalChallenges =
+            CVarDef.Create("stationware.total_challenges", 10, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     How much time do we wait between each challenge
+        /// </summary>
+        public static readonly CVarDef<float> StationWareChallengeCooldownLength =
+            CVarDef.Create("stationware.challenge_cooldown_length", 5f, CVar.SERVERONLY);
+
+        /// <summary>
         ///     Do we delete bodies once they die?
         /// </summary>
         public static readonly CVarDef<bool> StationWareMobsDeleteDeadBodies =

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-stationware.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-stationware.ftl
@@ -1,2 +1,8 @@
 stationware-title = StationWare
 stationware-description = Get the most points by completing an array of wacky challenges.
+
+stationware-report-score = [bold]{$place}.[/bold] [color=cyan]{$name}[/color] had a score of [color=yellow]{$points}.[/color]
+stationware-report-winner = {$points ->
+    [one] [color=cyan]{$name}[/color] was the winner with a measly [color=yellow]{$points} point![/color]
+    *[other] [color=cyan]{$name}[/color] was the winner with a total of [color=yellow]{$points} points![/color]
+}

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-stationware.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-stationware.ftl
@@ -1,7 +1,7 @@
 stationware-title = StationWare
 stationware-description = Get the most points by completing an array of wacky challenges.
 
-stationware-report-score = [bold]{$place}.[/bold] [color=cyan]{$name}[/color] had a score of [color=yellow]{$points}.[/color]
+stationware-report-score = [bold]{$place}.[/bold] [color=cyan]{$name}[/color] had a score of [color=yellow]{$points}[/color]
 stationware-report-winner = {$points ->
     [one] [color=cyan]{$name}[/color] was the winner with a measly [color=yellow]{$points} point![/color]
     *[other] [color=cyan]{$name}[/color] was the winner with a total of [color=yellow]{$points} points![/color]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
actually makes the endscreen not ugly, adds start delay for events, adds some CVARs for modifying some shit about the stationware gamerule itself. 

![image](https://user-images.githubusercontent.com/98561806/220822480-d63692c1-9b40-4157-a94d-8ad8b7d6723f.png)


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->
no cl no fun
