### PR TITLE
Respawn players at the end of stationware challenges

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Player.cs
+++ b/Content.Server/GameTicking/GameTicker.Player.cs
@@ -123,9 +123,10 @@ namespace Content.Server.GameTicking
             return (HumanoidCharacterProfile) _prefsManager.GetPreferences(p.UserId).SelectedCharacter;
         }
 
-        public void PlayerJoinGame(IPlayerSession session)
+        public void PlayerJoinGame(IPlayerSession session, bool sendMessage = true)
         {
-            _chatManager.DispatchServerMessage(session, Loc.GetString("game-ticker-player-join-game-message"));
+            if (sendMessage)
+                _chatManager.DispatchServerMessage(session, Loc.GetString("game-ticker-player-join-game-message"));
 
             _playerGameStatuses[session.UserId] = PlayerGameStatus.JoinedGame;
 

--- a/Content.Server/Mind/Mind.cs
+++ b/Content.Server/Mind/Mind.cs
@@ -203,7 +203,7 @@ namespace Content.Server.Mind
         /// <exception cref="ArgumentException">
         ///     Thrown if we already have a role with this type.
         /// </exception>
-        public Role AddRole(Role role)
+        public Role AddRole(Role role, bool greet = true)
         {
             if (_roles.Contains(role))
             {
@@ -211,7 +211,8 @@ namespace Content.Server.Mind
             }
 
             _roles.Add(role);
-            role.Greet();
+            if (greet)
+                role.Greet();
 
             var message = new RoleAddedEvent(this, role);
             if (OwnedEntity != null)

--- a/Content.Server/_StationWare/Challenges/Modifiers/Systems/StayAliveModifierSystem.cs
+++ b/Content.Server/_StationWare/Challenges/Modifiers/Systems/StayAliveModifierSystem.cs
@@ -31,6 +31,9 @@ public sealed class StayAliveModifierSystem : EntitySystem
     {
         foreach (var (stayAlive, challenge) in EntityQuery<StayAliveModifierComponent, StationWareChallengeComponent>())
         {
+            if (!challenge.Participants.ContainsValue(ev.Target))
+                continue;
+
             if (_mobState.IsIncapacitated(ev.Target, ev.Component))
                 _stationWareChallenge.SetPlayerChallengeState(ev.Target, stayAlive.Owner, false, challenge);
         }

--- a/Content.Server/_StationWare/Challenges/Modifiers/Systems/StayAliveModifierSystem.cs
+++ b/Content.Server/_StationWare/Challenges/Modifiers/Systems/StayAliveModifierSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Server._StationWare.Challenges.Modifiers.Components;
+using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
 
 namespace Content.Server._StationWare.Challenges.Modifiers.Systems;
@@ -12,13 +13,26 @@ public sealed class StayAliveModifierSystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<StayAliveModifierComponent, BeforeChallengeEndEvent>(OnBeforeChallengeEnd);
+        SubscribeLocalEvent<MobStateChangedEvent>(OnMobStateChanged);
     }
 
     private void OnBeforeChallengeEnd(EntityUid uid, StayAliveModifierComponent component, ref BeforeChallengeEndEvent args)
     {
+        if (!TryComp<StationWareChallengeComponent>(uid, out var challenge))
+            return;
+
         foreach (var player in args.Players)
         {
-            _stationWareChallenge.SetPlayerChallengeState(player, uid, _mobState.IsAlive(player));
+            _stationWareChallenge.SetPlayerChallengeState(player, uid, _mobState.IsAlive(player), challenge);
+        }
+    }
+
+    private void OnMobStateChanged(MobStateChangedEvent ev)
+    {
+        foreach (var (stayAlive, challenge) in EntityQuery<StayAliveModifierComponent, StationWareChallengeComponent>())
+        {
+            if (_mobState.IsIncapacitated(ev.Target, ev.Component))
+                _stationWareChallenge.SetPlayerChallengeState(ev.Target, stayAlive.Owner, false, challenge);
         }
     }
 }

--- a/Content.Server/_StationWare/Challenges/StationWareChallengeSystem.cs
+++ b/Content.Server/_StationWare/Challenges/StationWareChallengeSystem.cs
@@ -1,5 +1,8 @@
 ﻿using System.Linq;
+using Content.Server.Administration.Commands;
 using Content.Server.Chat.Systems;
+using Content.Server.GameTicking;
+using Content.Server.Ghost.Components;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Robust.Server.GameObjects;
@@ -22,6 +25,7 @@ public sealed partial class StationWareChallengeSystem : EntitySystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly ISerializationManager _serialization = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
+    [Dependency] private readonly GameTicker _gameTicker = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
 
@@ -92,8 +96,7 @@ public sealed partial class StationWareChallengeSystem : EntitySystem
 
         var ev = new ChallengeEndEvent(component.Participants.Values.ToList(), finalCompletions, uid);
         RaiseLocalEvent(uid, ref ev, true);
-
-        // TODO: we need to rejuv/respawn everyone we murdered
+        RespawnPlayers(component.Participants.Keys.ToList());
         Del(uid);
     }
 
@@ -149,6 +152,25 @@ public sealed partial class StationWareChallengeSystem : EntitySystem
             participants.Add(actor.PlayerSession, ent);
         }
         return participants;
+    }
+
+    private void RespawnPlayers(List<IPlayerSession> players)
+    {
+        foreach (var session in players)
+        {
+            // they belong to the void now
+            if (session.AttachedEntity is not { } entity)
+                continue;
+
+            if (HasComp<GhostComponent>(entity) || // are you a ghostie?
+                !HasComp<MobStateComponent>(entity)) // or did you get your ass gibbed
+            {
+                _gameTicker.SpawnPlayer(session, EntityUid.Invalid, null, false, false);
+                continue;
+            }
+
+            RejuvenateCommand.PerformRejuvenate(entity);
+        }
     }
 
     public override void Update(float frameTime)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Closes #43 

also modifies some code so it doesn't bug you with announcements every time.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

no cl no fun